### PR TITLE
Fulfilment datatype change in search

### DIFF
--- a/src/service/search/search.service.ts
+++ b/src/service/search/search.service.ts
@@ -642,7 +642,7 @@ export class SearchService {
                     : {}),
                   fulfillments: e.fulfillments.data.map((data: any) => {
                     return {
-                      id: data?.id,
+                      id: data?.id.toString(),
                       type: data.attributes.type,
                       rating: data?.attributes?.rating.toString()
                         ? data?.attributes?.rating.toString()


### PR DESCRIPTION
Fix for the error:request.body.message.catalog.providers[0].items[0].fulfillment_ids[0] should be string